### PR TITLE
Add CSS to discourage large groups

### DIFF
--- a/app/assets/stylesheets/root.css
+++ b/app/assets/stylesheets/root.css
@@ -41,15 +41,15 @@
 
 .settings__tooltip:before{
 	content: "";
-  border: solid 1em transparent; 
-  border-bottom-color: #404040; 
-  border-top: 0; 
+  border: solid 1em transparent;
+  border-bottom-color: #404040;
+  border-top: 0;
   width: 0;
   height: 0;
   overflow: hidden;
   display: block;
   position: relative;
-  top: -2em; 
+  top: -2em;
   margin-left: 85%;
 }
 
@@ -77,7 +77,7 @@
 
 .group-afternoon{
 	border-bottom: 5px solid green;
-	
+
 }
 
 
@@ -181,4 +181,21 @@
 .github-icon{
 	width: 1em;
 	height: 1em;
+}
+
+div p:nth-of-type(7) ~ p {
+    color: red;
+}
+
+div p:nth-of-type(7)::after {
+    content: "group full";
+    display: block;
+    border-top: 2px dashed;
+    height: 0px;
+    color: black;
+    width: 100%;
+    margin-top: 5px;
+    margin-bottom: 10px;
+    font-size: 10px;
+    text-align: center;
 }


### PR DESCRIPTION
One problem we've run into using this instead of the old spreadsheet is too-large groups. Rather than disabling joining groups above a certain size outright, this just adds some discouraging CSS that comes into play when the group is larger than 6 people. It looks like this:

![image](https://cloud.githubusercontent.com/assets/2532521/15517272/effaf588-21c4-11e6-8fdf-f697d52a250a.png)
