### PR TITLE
clear groups on Thursday

### DIFF
--- a/app/jobs/clear_groups_job.rb
+++ b/app/jobs/clear_groups_job.rb
@@ -4,8 +4,9 @@ class ClearGroupsJob < ActiveJob::Base
   def perform(*args)
     recursers = Recurser.all
     recursers.each do |rcer|
-    	rcer.update({:group_id => nil})
+      rcer.update({:group_id => nil})
     end
-    ClearGroupsJob.delay(run_at: Time.now.midnight + (86400*7)).perform_later
+    one_week_from_now = Time.now + 86400*7
+    ClearGroupsJob.delay(run_at: one_week_from_now).perform_later
   end
 end

--- a/app/jobs/clear_groups_job.rb
+++ b/app/jobs/clear_groups_job.rb
@@ -6,7 +6,6 @@ class ClearGroupsJob < ActiveJob::Base
     recursers.each do |rcer|
       rcer.update({:group_id => nil})
     end
-    one_week_from_now = Time.now + 86400*7
-    ClearGroupsJob.delay(run_at: one_week_from_now).perform_later
+    ClearGroupsJob.delay(run_at: 1.week.from_now).perform_later
   end
 end

--- a/bin/start_recurring_jobs.rb
+++ b/bin/start_recurring_jobs.rb
@@ -5,7 +5,7 @@ def date_of_next(day)
 end
 
 def main
-  job_time = date_of_next("Thursday") + 12.hours
+  job_time = date_of_next("Thursday") + 13.5.hours
   jobs = Delayed::Job.where(queue: "clear_groups")
 
   if jobs.length == 0

--- a/bin/start_recurring_jobs.rb
+++ b/bin/start_recurring_jobs.rb
@@ -4,15 +4,9 @@ def date_of_next(day)
   date + delta
 end
 
-def main
-  job_time = date_of_next("Thursday") + 13.5.hours
-  jobs = Delayed::Job.where(queue: "clear_groups")
+job_time = date_of_next("Thursday") + 13.5.hours
+jobs = Delayed::Job.where(queue: "clear_groups")
 
-  if jobs.length == 0
-    ClearGroupsJob.delay(queue: "clear_groups", run_at: job_time).perform_later
-  end
-end
-
-if __FILE__ == $0
-  main
+if jobs.length == 0
+  ClearGroupsJob.delay(queue: "clear_groups", run_at: job_time).perform_later
 end

--- a/bin/start_recurring_jobs.rb
+++ b/bin/start_recurring_jobs.rb
@@ -1,16 +1,18 @@
-weekday = Time.zone.now.wday
-
-if weekday <= 4
-  days_til_Friday = 5-weekday 	
-else
-	days_til_Friday = 6-weekday+6
+def date_of_next(day)
+  date  = Date.parse(day)
+  delta = date > Date.today ? 0 : 7
+  date + delta
 end
 
-job_time =  Time.now.midnight + (86400*days_til_Friday)
+def main
+  job_time = date_of_next("Thursday") + 12.hours
+  jobs = Delayed::Job.where(queue: "clear_groups")
 
+  if jobs.length == 0
+    ClearGroupsJob.delay(queue: "clear_groups", run_at: job_time).perform_later
+  end
+end
 
-jobs = Delayed::Job.where(queue: "clear_groups")
-
-if jobs.length == 0
-	ClearGroupsJob.delay(queue: "clear_groups", run_at: job_time).perform_later
+if __FILE__ == $0
+  main
 end


### PR DESCRIPTION
Make group clearing happen on Thursday at noon, rather than Friday at midnight, along with a couple formatting fixes / cleanups.
