### PR TITLE
Fix scheduling

### DIFF
--- a/app/controllers/recursers_controller.rb
+++ b/app/controllers/recursers_controller.rb
@@ -110,12 +110,11 @@ class RecursersController < ApplicationController
 
 
     # checks if we're scheduling jobs for this week or next week
-    # wday (4) == Thursday
+    # wday (3) == Weds
     weekday = Time.zone.now.wday
-    if weekday <= 4
+    if weekday <= 3
       thisweek = true
       start = weekday
-
     else
       thisweek = false
       start = 1

--- a/app/controllers/recursers_controller.rb
+++ b/app/controllers/recursers_controller.rb
@@ -1,152 +1,152 @@
 class RecursersController < ApplicationController
-	CLIENT_ID = Rails.application.secrets.RC_API_ID
-	CLIENT_SECRET = Rails.application.secrets.RC_API_SECRET
-	REDIRECT_URI  = Rails.application.secrets.RC_API_URI
-	SITE          = 'https://www.recurse.com'
+  CLIENT_ID = Rails.application.secrets.RC_API_ID
+  CLIENT_SECRET = Rails.application.secrets.RC_API_SECRET
+  REDIRECT_URI  = Rails.application.secrets.RC_API_URI
+  SITE          = 'https://www.recurse.com'
 
-	def start_auth
-		client = create_client
-		redirect_to client.auth_code.authorize_url(redirect_uri: REDIRECT_URI)
+  def start_auth
+    client = create_client
+    redirect_to client.auth_code.authorize_url(redirect_uri: REDIRECT_URI)
   end
 
   def auth_callback
-  	client = create_client
-  	code = params[:code]
-  	token = client.auth_code.get_token(code, redirect_uri: REDIRECT_URI)
-  	session["token"] = token
-  	user = JSON.parse(token.get("/api/v1/people/me").body)
-  	authed_user = {:name => user["first_name"] + " " +  user["last_name"], :email => user["email"], :zulip_email => user["email"]}
-  	create(authed_user)
+    client = create_client
+    code = params[:code]
+    token = client.auth_code.get_token(code, redirect_uri: REDIRECT_URI)
+    session["token"] = token
+    user = JSON.parse(token.get("/api/v1/people/me").body)
+    authed_user = {:name => user["first_name"] + " " +  user["last_name"], :email => user["email"], :zulip_email => user["email"]}
+    create(authed_user)
   end
 
 
-	def new
-		@recurser = Recurser.new
-	end
+  def new
+    @recurser = Recurser.new
+  end
 
-	def create(user)
-		@recurser = Recurser.find_by email: user[:email]
-		
-		if @recurser
-			update_session_user(@recurser.id)
-			redirect_to "/"
+  def create(user)
+    @recurser = Recurser.find_by email: user[:email]
 
-		else
-			@recurser = Recurser.new(user)
-			if @recurser.save
-				update_session_user(@recurser.id)
-				redirect_to "/"
-			else
-				render 'new'
-			end
+    if @recurser
+      update_session_user(@recurser.id)
+      redirect_to "/"
 
-		end
-	end
+    else
+      @recurser = Recurser.new(user)
+      if @recurser.save
+	update_session_user(@recurser.id)
+	redirect_to "/"
+      else
+	render 'new'
+      end
 
-	def edit
-		current_user #sets @_current_user variable
-	end
+    end
+  end
 
-	def update
-		current_user #sets @_current_user variable
+  def edit
+    current_user #sets @_current_user variable
+  end
 
-		#group_id is a different edit case, it's not passed in as part of recurser_params
-		if params[:group_id]
-			@_current_user.update({:group_id => params[:group_id]})
+  def update
+    current_user #sets @_current_user variable
 
-			ping_success = schedule_pings
-			
+    #group_id is a different edit case, it's not passed in as part of recurser_params
+    if params[:group_id]
+      @_current_user.update({:group_id => params[:group_id]})
 
-			redirect_to controller: :groups, action: :index , ping_success: ping_success.to_s
-		elsif @_current_user.update(recurser_params)
-			redirect_to "/"
-		else
-			render "edit"
-		end
-	end
-
-	def leave_group
-		current_user #sets @_current_user variable
-		@_current_user.update({:group_id => nil})
-		remove_existing_pings
-		redirect_to "/"
-	end
+      ping_success = schedule_pings
 
 
-	def destroy
-		@recurser = Recurser.find(params[:id])
+      redirect_to controller: :groups, action: :index , ping_success: ping_success.to_s
+    elsif @_current_user.update(recurser_params)
+      redirect_to "/"
+    else
+      render "edit"
+    end
+  end
+
+  def leave_group
+    current_user #sets @_current_user variable
+    @_current_user.update({:group_id => nil})
+    remove_existing_pings
+    redirect_to "/"
+  end
+
+
+  def destroy
+    @recurser = Recurser.find(params[:id])
     @recurser.destroy
     redirect_to "/"
   end
 
 
-	private
-		def recurser_params
-			params.require(:recurser).permit(:name, :email, :group_id, :zulip_email)
-		end
+  private
+  def recurser_params
+    params.require(:recurser).permit(:name, :email, :group_id, :zulip_email)
+  end
 
-		def update_session_user(id)
-			session[:user_id]= id
-		end
+  def update_session_user(id)
+    session[:user_id]= id
+  end
 
-		def create_client
-			OAuth2::Client.new(CLIENT_ID, CLIENT_SECRET, site: SITE)
-		end
+  def create_client
+    OAuth2::Client.new(CLIENT_ID, CLIENT_SECRET, site: SITE)
+  end
 
-		def remove_existing_pings
-			jobs = Delayed::Job.where(queue: @_current_user.email)
-  		jobs.each do |job|
-  			Delayed::Job.find(job.id).destroy
-  		end
-  	end
+  def remove_existing_pings
+    jobs = Delayed::Job.where(queue: @_current_user.email)
+    jobs.each do |job|
+      Delayed::Job.find(job.id).destroy
+    end
+  end
 
-		def schedule_pings
-	    remove_existing_pings
+  def schedule_pings
+    remove_existing_pings
 
-	  	# find the correct time of day to ping
-	  	# Time.parse will default to TODAY
-	    group = Group.find(@_current_user.group_id)
-	    pingtime = Time.parse(group.time)
-	    
-	    
-	    # checks if we're scheduling jobs for this week or next week
-	    # wday (4) == Thursday
-	    weekday = Time.zone.now.wday
-	    if weekday <= 4
-	    	thisweek = true
-	    	start = weekday
-	    	
-	    else
-	    	thisweek = false
-	    	start = 1
-	    end
+    # find the correct time of day to ping
+    # Time.parse will default to TODAY
+    group = Group.find(@_current_user.group_id)
+    pingtime = Time.parse(group.time)
 
-	    if !thisweek
-		  	#since Time.parse defaults to today, add some days to start next Monday
-		  	pingtime = pingtime + (86400 * (6-weekday+2))
-		  end
-		  
-		  scheduled_something = false
 
-	    # schedule the correct number of jobs on correct days
-	    (start..4).each do |w|
-	    	# adds days to the pingtime(value for + is in seconds)
-	    	dailypingtime = pingtime + (86400 * (w-start))
+    # checks if we're scheduling jobs for this week or next week
+    # wday (4) == Thursday
+    weekday = Time.zone.now.wday
+    if weekday <= 4
+      thisweek = true
+      start = weekday
 
-	    	# schedule a ping
-	    	content = "Your check-in starts now in #{group.room}."
-	    	if dailypingtime > Time.zone.now
-	    		scheduled_something = true
-	    		ZulipPingJob.delay(queue: @_current_user.email, run_at: dailypingtime).perform_later(@_current_user.zulip_email, content)
-	    	end
-	    end
+    else
+      thisweek = false
+      start = 1
+    end
 
-	    jobs = Delayed::Job.where(queue: @_current_user.email)
-  		jobs.each do |job|
-  			puts job
-  		end
+    if !thisweek
+      #since Time.parse defaults to today, add some days to start next Monday
+      pingtime = pingtime + (86400 * (6-weekday+2))
+    end
 
-	    scheduled_something #return whether something was scheduled
-	  end
+    scheduled_something = false
+
+    # schedule the correct number of jobs on correct days
+    (start..4).each do |w|
+      # adds days to the pingtime(value for + is in seconds)
+      dailypingtime = pingtime + (86400 * (w-start))
+
+      # schedule a ping
+      content = "Your check-in starts now in #{group.room}."
+      if dailypingtime > Time.zone.now
+	scheduled_something = true
+	ZulipPingJob.delay(queue: @_current_user.email, run_at: dailypingtime).perform_later(@_current_user.zulip_email, content)
+      end
+    end
+
+    jobs = Delayed::Job.where(queue: @_current_user.email)
+    jobs.each do |job|
+      puts job
+    end
+
+    scheduled_something #return whether something was scheduled
+  end
 
 end

--- a/app/controllers/recursers_controller.rb
+++ b/app/controllers/recursers_controller.rb
@@ -136,7 +136,13 @@ class RecursersController < ApplicationController
       content = "Your check-in starts now in #{group.room}."
       if dailypingtime > Time.zone.now
 	scheduled_something = true
-	ZulipPingJob.delay(queue: @_current_user.email, run_at: dailypingtime).perform_later(@_current_user.zulip_email, content)
+	ZulipPingJob.delay(
+          queue: @_current_user.email,
+          run_at: dailypingtime
+        ).perform_later(
+          @_current_user.zulip_email,
+          content
+        )
       end
     end
 

--- a/app/helpers/groups_helper.rb
+++ b/app/helpers/groups_helper.rb
@@ -1,12 +1,12 @@
 module GroupsHelper
-	def ping_success_helper(ping_success)
-		if ping_success == "true"
-		 return "Your check-ins have been scheduled."
-		elsif Time.zone.now.thursday?
-			return "You haven't actually signed up for a group... Come back tomorrow!"
-		else
-			return "Something went wrong..."
-		end
-	end
+  def ping_success_helper(ping_success)
+    if ping_success == "true"
+      return "Your check-ins have been scheduled."
+    elsif Time.zone.now.thursday?
+      return "You haven't actually signed up for a group... Come back tomorrow!"
+    else
+      return "Something went wrong..."
+    end
+  end
 
 end

--- a/app/helpers/groups_helper.rb
+++ b/app/helpers/groups_helper.rb
@@ -2,8 +2,6 @@ module GroupsHelper
   def ping_success_helper(ping_success)
     if ping_success == "true"
       return "Your check-ins have been scheduled."
-    elsif Time.zone.now.thursday?
-      return "You haven't actually signed up for a group... Come back tomorrow!"
     else
       return "Something went wrong..."
     end

--- a/app/jobs/clear_groups_job.rb
+++ b/app/jobs/clear_groups_job.rb
@@ -1,5 +1,5 @@
 class ClearGroupsJob < ActiveJob::Base
-  queue_as :default
+  queue_as :clear_groups
 
   def perform(*args)
     recursers = Recurser.all


### PR DESCRIPTION
I inadvertently broke scheduling of ping jobs when I changed the group clear time to Thurs. This fixes it so that signing up on Weds signs you up for the current week, while signing up on Thurs signs you up for next week.

The diff is noisy because of formatting and whitespace changes but the relevant commits are https://github.com/ksullivan2/rc-checkins-rails/commit/74f7590f1a66c824d9cf45a65b8575b62699d92e, which changes the job scheduling, and https://github.com/ksullivan2/rc-checkins-rails/pull/9/commits/89a0ab55c5dd85d022591918927f126ebbc27a17, which removes the visual warning when you sign up on Thursday.
