### PR TITLE
Update the Zulip API URI for the Ping Job

### DIFF
--- a/app/jobs/zulip_ping_job.rb
+++ b/app/jobs/zulip_ping_job.rb
@@ -1,7 +1,7 @@
 class ZulipPingJob < ActiveJob::Base
   queue_as :default
 
-  @@uri = URI("https://api.zulip.com/v1/messages")
+  @@uri = URI("https://recurse.zulipchat.com/api/v1/messages")
 
   def perform(email, content)
   	zulip_post('type' => 'private', 'content' => content, 'to' => email)


### PR DESCRIPTION
After the recent Zulip migration, the API endpoints have been changed. This pull request proposes updating the URI stored in the class variable of the `ZulipPingJob` class so that Zulip reminders will be able to function again.

This is a band-aid quality pull request because people have been missing their check-ins. But since it's only a small change, I'm thinking it won't have any unintended side-effects.
